### PR TITLE
expand kotlin bootstrap convention template

### DIFF
--- a/bootstrap/language_conventions/java_coding_conventions_template.md
+++ b/bootstrap/language_conventions/java_coding_conventions_template.md
@@ -53,13 +53,27 @@
 - 24+에서 표준화된 기능으로 대체 가능한 보조 유틸리티나 관성적 패턴이 있으면 새 라이브러리 추가보다 JDK 표준 기능을 우선 검토한다.
 - preview 기능은 도입 이유, 롤백 가능성, 대체안이 없으면 기본 convention으로 채택하지 않는다.
 
-## Effective Java 적용 관점
+## 참조 관점
 
-- 아래 항목은 사용자가 가져온 `Effective Java` 분류를 Java bootstrap convention으로 재정리한 것이다.
-- 책의 모든 항목을 그대로 복제하지 않고, 현재 harness의 project-facing bootstrap 자산에 맞는 Java-specific 판단 기준만 남긴다.
-- 공통 프로세스, 경계 번역, 테스트 책임, 에러 처리의 기본 규칙은 `docs/standard/coding_guidelines_core.md`를 우선하고, 여기서는 Java에서 반복적으로 결정해야 하는 구체 선택만 추가한다.
+- 아래 항목은 `Effective Java`의 장별 주제를 project-facing bootstrap convention으로 재정리한 것이다.
+- 책의 모든 항목을 그대로 복제하지 않고, project-facing bootstrap 자산에서 바로 복사하거나 현지화할 수 있는 Java-specific 선택 기준만 남긴다.
 
-## 2장 객체 생성과 파괴
+## 타입과 모델링
+
+- 값 의미가 있는 타입은 mutable POJO보다 `record` 또는 명시적 값 객체를 우선 검토한다.
+- `equals`를 재정의하면 `hashCode`도 함께 맞추고, hash 기반 컬렉션 사용 시 테스트로 확인한다.
+- 자연 순서가 있는 값 타입은 `Comparable` 구현을 검토하되 `equals`와 충돌하지 않게 유지한다.
+- 값 의미가 있는 타입은 `toString` 재정의를 검토하되 민감정보는 직접 노출하지 않는다.
+- enum 외부 계약에는 ordinal을 사용하지 않고, 필요한 값은 명시 필드로 둔다.
+- 상태 집합 연산은 bit field보다 `EnumSet`을, enum key 기반 매핑은 배열 인덱싱보다 `EnumMap`을 우선 검토한다.
+- API가 구체 구현보다 추상 계약에 의존하게 `List`, `Set`, `Map` 같은 인터페이스 타입을 우선 노출한다.
+- 식별자, 복합 키, 상태를 단순 문자열 하나에 몰아넣지 말고 더 적절한 타입을 검토한다.
+- `Optional`은 반환 타입에서만 우선 사용하고, 엔티티 필드, DTO 필드, 직렬화 모델 필드의 기본 표현으로 삼지 않는다.
+- `Optional<List<T>>`, `Optional<Set<T>>`, `Optional<T[]>`, `Optional<Stream<T>>`보다 빈 결과를 반환한다.
+- `Optional.get()`을 기본 흐름 제어로 사용하지 않고, `orElseThrow`, `map`, `flatMap`, `ifPresent` 같은 의도를 드러내는 연산을 우선한다.
+- `isPresent()` 후 `get()`으로 다시 꺼내는 패턴은 분기 책임이 분명하지 않으면 피한다.
+
+## 객체 생성과 API 설계
 
 - 생성자 오버로드가 의미를 숨기면 named static factory를 우선 검토한다.
 - 선택 인자가 많아지는 타입은 telescoping constructor보다 builder 또는 별도 request/value type을 우선 검토한다.
@@ -70,90 +84,47 @@
 - listener, cache, thread-local, static registry에 넣은 참조는 수명주기와 해제 책임을 함께 문서화한다.
 - finalizer와 cleaner는 기본 자원 정리 수단으로 사용하지 않는다.
 - `AutoCloseable` 자원은 `try-finally`보다 `try-with-resources`를 기본으로 사용한다.
+- public API는 boxed primitive, `null`, sentinel value를 섞어 애매한 계약을 만들지 않는다.
+- 컬렉션 내부 상태를 그대로 노출하지 않고, 방어적 복사 또는 불변 뷰 필요 여부를 계약으로 명시한다.
+- public/protected 메서드는 매개변수 유효성 검사를 빠뜨리지 않는다.
+- mutable 입력과 내부 상태 노출이 계약을 깨뜨릴 수 있으면 방어적 복사를 검토한다.
+- 컬렉션이나 배열 결과가 비어 있을 수 있으면 `null` 대신 빈 값을 반환한다.
 
-## 3장 모든 객체의 공통 메서드
-
-- 값 의미가 있는 타입만 `equals`를 재정의하고, 대칭성/추이성/일관성을 깨는 설계는 피한다.
-- `equals`를 재정의하면 `hashCode`도 함께 맞추고, hash 기반 컬렉션 사용 시 테스트로 확인한다.
-- 공개 value type과 디버깅 가치가 높은 타입은 `toString` 재정의를 검토하되 민감정보는 직접 노출하지 않는다.
-- `Cloneable`/`clone`은 기본 선택지로 쓰지 않고, 복제가 필요하면 복사 생성자나 복사 팩터리를 우선 검토한다.
-- 자연 순서가 있는 값 타입은 `Comparable` 구현을 검토하되 `equals`와 충돌하지 않게 유지한다.
-
-## 4장 클래스와 인터페이스
+## 함수와 추상화 설계
 
 - 클래스와 멤버의 접근 권한은 가능한 최소로 유지한다.
 - public 클래스는 mutable public 필드 대신 접근자와 명시적 메서드 계약을 사용한다.
-- 변경이 거의 없는 값 객체는 mutable POJO보다 불변 타입을 우선한다.
 - 상속보다 합성을 우선하고, 상속은 진짜 is-a 관계와 override 계약을 유지할 수 있을 때만 사용한다.
 - 상속을 열어 두는 클래스는 protected hook, 호출 순서, 상태 불변식까지 문서화하고, 그렇지 않으면 상속을 막는다.
 - public 확장 지점은 추상 클래스보다 인터페이스를 우선 검토한다.
 - 인터페이스는 타입을 표현하는 용도로 쓰고, 상수 묶음 역할은 지양한다.
 - 태그 값으로 분기하는 클래스보다 sealed hierarchy 또는 명시적 타입 계층을 우선 검토한다.
 - 바깥 인스턴스가 필요 없는 멤버 클래스는 static nested class를 우선 사용한다.
-- 톱레벨 타입은 가능한 한 파일당 하나로 유지한다.
-
-## 5장 제네릭
-
 - raw type은 사용하지 않는다.
 - 비검사 경고는 무시하지 말고 제거하거나, 정말 필요한 경우 가장 좁은 범위에서만 근거와 함께 억제한다.
-- 공개 API에서는 배열보다 `List` 같은 컬렉션 인터페이스를 우선 검토한다.
 - 타입 관계가 반복되는 도우미는 제네릭 타입 또는 제네릭 메서드로 일반화할 수 있는지 검토한다.
 - producer/consumer 성격이 분명한 API는 bounded wildcard로 유연성을 높일 수 있는지 검토한다.
 - 제네릭과 가변인수를 함께 쓸 때는 힙 오염 가능성을 확인하고, 안전성이 명확할 때만 제한적으로 사용한다.
 - 타입 안전 이종 컨테이너 패턴은 ad-hoc `Map<String, Object>`보다 계약이 더 분명해질 때만 사용한다.
+- reflection보다는 인터페이스와 명시적 계약을 우선 사용한다.
 
-## 6장 열거 타입과 애너테이션
+## 컬렉션과 데이터 처리
 
-- int/string 상수 묶음보다 enum을 우선 사용한다.
-- enum의 외부 계약에는 ordinal을 사용하지 않고, 필요한 값은 명시 필드로 둔다.
-- 상태 집합 연산은 bit field보다 `EnumSet`을 우선 검토한다.
-- enum key 기반 매핑은 배열 인덱싱보다 `EnumMap`을 우선 검토한다.
-- 확장 가능한 enum 유사 구조가 필요하면 인터페이스와 다형성을 우선 검토한다.
-- 명명 패턴 규칙보다 annotation 기반 메타데이터를 우선 검토한다.
-- 재정의 메서드에는 `@Override`를 일관되게 사용한다.
-- 타입 정체성이 필요한 마킹에는 marker annotation보다 marker interface가 더 맞는지 검토한다.
-
-## 7장 람다와 스트림
-
-- 익명 클래스보다 람다가 더 짧고 명확하면 람다를 사용한다.
-- 람다보다 메서드 참조가 더 읽기 쉬울 때만 메서드 참조로 바꾼다.
-- ad-hoc 함수 타입보다 표준 함수형 인터페이스를 우선 검토한다.
-- stream은 선언형 구성이 더 읽기 쉬울 때 사용하고, 그렇지 않으면 loop를 선택한다.
+- 한 번의 명시적 loop가 더 읽기 쉬우면 stream보다 loop를 선택한다.
+- stream 파이프라인은 mapping/filtering/aggregation 책임이 한눈에 읽히는 길이까지만 허용한다.
 - stream 안에는 부작용 없는 함수를 유지하고, 상태 변경을 숨기지 않는다.
 - 재사용 가능한 결과를 반환할 때는 `Stream`보다 `Collection` 반환이 더 나은지 먼저 검토한다.
 - `parallelStream()`은 기본값으로 사용하지 않고, workload 특성과 검증 근거가 있을 때만 도입한다.
-
-## 8장 메서드
-
-- public/protected 메서드는 매개변수 유효성 검사를 빠뜨리지 않는다.
-- mutable 입력과 내부 상태 노출이 계약을 깨뜨릴 수 있으면 방어적 복사를 검토한다.
-- 메서드 시그니처는 boolean flag, 같은 타입의 연속 파라미터, 의미가 숨은 overload를 줄이도록 설계한다.
-- 다중정의는 boxing, varargs, lambda 추론과 충돌하지 않게 신중히 사용한다.
-- 가변인수는 정말 가변 개수 의미가 있을 때만 쓰고, hot path면 고정 인자 오버로드가 더 나은지 검토한다.
-- 컬렉션이나 배열 결과가 비어 있을 수 있으면 `null` 대신 빈 값을 반환한다.
-- `Optional`은 반환 타입에서만 우선 사용하고, 엔티티 필드, DTO 필드, 직렬화 모델 필드의 기본 표현으로 삼지 않는다.
-- `Optional<List<T>>`, `Optional<Set<T>>`, `Optional<T[]>`, `Optional<Stream<T>>`보다 빈 결과를 반환한다.
-- `Optional.get()`을 기본 흐름 제어로 사용하지 않고, `orElseThrow`, `map`, `flatMap`, `ifPresent` 같은 의도를 드러내는 연산을 우선한다.
-- `isPresent()` 후 `get()`으로 다시 꺼내는 패턴은 분기 책임이 분명하지 않으면 피한다.
-- nullable API와 `Optional` API를 같은 계층에 함께 노출하지 않도록 프로젝트 기준을 통일한다.
-- 외부에 공개되는 API는 Javadoc 유지 범위와 작성 수준을 프로젝트에서 정한다.
-
-## 9장 일반적인 프로그래밍 원칙
-
-- 지역변수의 범위는 가능한 한 좁게 유지한다.
-- index나 remove 제어가 필요 없으면 전통적 `for`보다 for-each를 우선 검토한다.
-- 표준 라이브러리로 충분한 기능은 직접 재구현하지 않는다.
+- 정렬, grouping, deduplication처럼 표준 collector로 충분한 경우 직접 상태 누적 코드를 반복하지 않는다.
+- 문자열 누적은 반복 `+`보다 `StringBuilder`, `StringJoiner`, collector가 더 명확한지 비교한다.
+- stream, lambda, boxing이 hot path에서 반복되면 loop, primitive specialization, 중간 객체 제거가 더 단순한지 먼저 검토한다.
+- `map().filter().collect()` 연쇄가 큰 중간 컬렉션을 여러 번 만들면 한 번의 순회로 줄일 수 있는지 확인한다.
+- `Stream<Integer>`처럼 boxing 비용이 반복되는 경로는 `IntStream`, `LongStream`, `DoubleStream` 적용 가능성을 검토한다.
 - 정확한 수치 계산이 필요하면 `float`/`double` 대신 프로젝트 표준 수치 타입을 명시한다.
 - hot path와 null 허용 비교에서는 boxed primitive보다 primitive를 우선 검토한다.
-- 식별자, 복합 키, 상태를 단순 문자열 하나에 몰아넣지 말고 더 적절한 타입을 검토한다.
-- 문자열 누적은 반복 `+`보다 `StringBuilder`, `StringJoiner`, collector가 더 명확한지 비교한다.
-- API가 구체 구현보다 추상 계약에 의존하게 `List`, `Set`, `Map` 같은 인터페이스 타입을 우선 노출한다.
-- reflection보다는 인터페이스와 명시적 계약을 우선 사용한다.
-- native method는 꼭 필요할 때만 사용하고, 대체 불가 사유를 남긴다.
 - 최적화는 측정 근거와 병목 정보가 있을 때만 도입한다.
-- 일반적으로 통용되는 Java naming convention을 따른다.
 
-## 10장 예외
+## 예외와 결과 표현
 
 - 예외는 진짜 예외 상황에만 사용하고 정상 흐름 제어 수단으로 남용하지 않는다.
 - 복구 가능한 상황은 checked exception, 프로그래밍 오류는 runtime exception이 더 맞는지 구분한다.
@@ -164,19 +135,20 @@
 - 예외를 무시하지 않고, 정말 삼켜야 하면 이유와 보완을 남긴다.
 - `InterruptedException`을 삼키지 않고 interrupt 의미를 보존한다.
 
-## 11장 동시성
+## 동시성과 비동기
 
 - 공유 mutable 상태는 동기화하거나, 더 먼저 공유 자체를 제거할 수 있는지 검토한다.
 - 과도한 동기화와 lock 내부 외부 호출을 피한다.
 - raw thread 생성보다 executor, task, concurrency utility를 우선 검토한다.
-- virtual thread는 기본 강제가 아니라 비교 검토 대상이며, thread-local, transaction, MDC, 외부 라이브러리 호환성은 `[프로젝트 결정 필요]`로 남긴다.
 - `wait`/`notify`보다 `java.util.concurrent` 유틸리티를 우선 검토한다.
 - thread-safety 수준을 프로젝트 문서나 타입 계약에 명시한다.
 - 지연 초기화는 동시성 비용과 초기화 비용을 비교해 신중히 사용한다.
 - correctness를 sleep, timing, scheduler 우연성에 기대지 않는다.
 
-## 12장 직렬화
+## Interop, Reflection, Serialization
 
+- native method는 꼭 필요할 때만 사용하고, 대체 불가 사유를 남긴다.
+- reflection, bytecode 조작, annotation processor, agent 기반 접근은 필요성과 대체 불가 사유가 있을 때만 도입한다.
 - 외부 경계 계약은 Java native serialization보다 명시적 포맷(JSON, Protobuf, 별도 mapper)을 우선 검토한다.
 - `Serializable` 구현은 장기 호환성과 공격 표면을 고려해 신중히 결정한다.
 - 직렬화가 꼭 필요하면 기본 직렬화 형태가 아니라 커스텀 직렬화 형태가 더 안전한지 검토한다.
@@ -184,11 +156,10 @@
 - 인스턴스 수 통제가 중요한 singleton은 `readResolve`보다 enum singleton이 더 맞는지 우선 검토한다.
 - 복잡한 직렬화 대상은 serialization proxy 패턴이 더 안전한지 검토한다.
 
-## import 와 dependency 사용 관례
+## Import 와 Dependency 사용 관례
 
 - static import는 assertion, math, enum constant처럼 반복 사용으로 오히려 의미가 선명해질 때만 제한적으로 사용한다.
 - 표준 JDK 기능으로 충분한 경우 작은 편의 라이브러리 추가보다 JDK 표준 API를 우선 검토한다.
-- reflection, bytecode 조작, annotation processor, agent 기반 접근은 필요성과 대체 불가 사유가 있을 때만 도입한다.
 - Lombok 같은 코드 생성 도구 사용 여부와 허용 범위는 `[프로젝트 결정 필요]`로 남긴다.
 
 ## 패키지와 파일 구조
@@ -196,6 +167,7 @@
 - 패키지 구조는 프로젝트의 구조 문서가 정한 책임 경계를 먼저 드러내고, framework 중심 그룹화만 남지 않게 정한다.
 - public 타입 이름은 역할 중심 명사로 두고, 구현 상세가 드러나는 `Impl`, `Util`, `Helper` 남용은 피한다.
 - 하나의 파일에는 함께 변경될 이유가 높은 타입만 둔다. 붙어 다니지 않는 보조 타입을 관성적으로 중첩시키지 않는다.
+- 톱레벨 타입은 가능한 한 파일당 하나로 유지한다.
 - record, enum, sealed hierarchy는 파일 배치만으로도 닫힌 모델 관계가 읽히게 유지한다.
 
 ## 테스트 관례 초안

--- a/bootstrap/language_conventions/kotlin_coding_conventions_template.md
+++ b/bootstrap/language_conventions/kotlin_coding_conventions_template.md
@@ -3,28 +3,168 @@
 ## 목적
 
 이 문서는 Kotlin 프로젝트 또는 Kotlin 모듈에 적용할 언어별 convention 초안이다.
+가능하면 `Effective Kotlin` 성격의 실무 원칙을 따르되, Kotlin의 null-safety, 불변성, 표현력, structured concurrency 장점을 기본값으로 활용한다.
 
 ## 사용 방법
 
 - 필요한 항목만 `docs/standard/coding_conventions_project.md`에 복사 또는 병합한다.
 - 다중 언어 프로젝트면 Kotlin 전용 문서로 분리한 뒤 프로젝트 문서에서 참조해도 된다.
+- framework, runtime, build tool, serialization, persistence 기술에 강하게 묶인 규칙은 `[프로젝트 결정 필요]`로 남긴다.
 
-## 기본 규칙
+## 코드 스타일과 convention 분리
 
-- null 가능성은 타입 시스템으로 우선 표현하고, `!!`는 마지막 수단으로만 사용한다.
-- scope function(`let`, `run`, `apply`, `also`, `with`)은 의도가 더 분명해질 때만 사용한다.
-- data class, sealed class, extension function은 언어 장점을 살리는 범위에서 쓰되 책임을 숨기지 않게 유지한다.
-- 경계 계층에서 외부 모델을 domain 또는 application 관점 타입으로 번역한다.
-- coroutine 사용 시 dispatcher 전환, cancellation, blocking 호출 경계를 문서로 분명히 한다.
+- import 위치/정렬, 공백, 줄바꿈, brace 위치, line length, unused import 같은 기계적으로 판별 가능한 규칙은 formatter/linter/build 또는 CI check로 강제한다.
+- 이 문서는 자동 검사로 대체하기 어려운 판단 규칙과 예외 기준을 남긴다.
+- tool 설정으로 고정 가능한 스타일 규칙은 여기서 길게 반복하지 않는다.
+
+## 공통 품질 규칙 참조
+
+- 공통 boundary translation, 에러 처리, 테스트 책임, 범위 제한 규칙은 `docs/standard/coding_guidelines_core.md`를 따른다.
+- 이 문서는 그 위에 Kotlin에서 반복적으로 결정해야 하는 언어별 선택 기준만 추가한다.
+
+## 적용 전 결정
+
+- 기준 Kotlin 버전과 주 타깃 런타임(JVM, Android, Multiplatform 등)을 먼저 정한다.
+- K2 compiler, explicit API mode, context receivers 같은 옵션성 기능은 `[프로젝트 결정 필요]`로 남긴다.
+- Java interop 비중, coroutine 사용 범위, serialization 방식, reflection 허용 범위를 함께 정한다.
+
+## 런타임과 언어 기능 검토 예시
+
+- JVM 중심 프로젝트면 platform type 정리, Java interop, annotation/serialization 전략을 먼저 정한다.
+- Android 또는 UI 환경이면 lifecycle과 cancellation 경계, state holder 패턴, dispatcher 사용 기준을 함께 정한다.
+- Multiplatform 프로젝트면 공통 모듈 추출과 `expect/actual` 경계를 실제 중복 감소가 있을 때만 도입한다.
+- coroutine, `Flow`, value class, compiler option은 기본 강제가 아니라 프로젝트 맥락에 맞는 선택 기준으로 남긴다.
+
+## 참조 관점
+
+- 아래 항목은 `Effective Kotlin`의 좋은 코드/코드 설계/효율성 분류와 `Kotlin in Action`의 언어 기능, interop, coroutine/flow 주제를 project-facing bootstrap convention으로 재정리한 것이다.
+- 책 내용을 그대로 복제하지 않고, project-facing bootstrap 자산에서 바로 복사하거나 현지화할 수 있는 Kotlin-specific 선택 기준만 남긴다.
+
+## 타입과 모델링
+
+- 기본 선택지는 `var`보다 `val`이다.
+- null 가능성은 타입으로 우선 표현하고, `!!`는 마지막 수단으로만 사용한다.
+- platform type은 Java 경계에서 최대한 빨리 nullable/non-null 계약으로 정규화한다.
+- nullable collection과 collection of nullable element를 혼동하지 않도록 타입 의미를 분명히 한다.
+- 결과가 없을 가능성이 있으면 nullable, `Result`, sealed result, 빈 컬렉션 중 하나로 프로젝트 기준을 통일한다.
+- 값 중심 모델은 `data class`를 우선 검토하되, 식별성/수명주기/프록시가 핵심이면 일반 클래스를 유지한다.
+- primitive wrapper가 도메인 의미와 검증을 명확히 하면 `@JvmInline value class`를 검토한다.
+- 닫힌 상태 집합과 결과 모델은 `sealed interface` 또는 `sealed class`를 우선 검토한다.
+- global state가 아닌 명시적 싱글턴 의미가 있을 때만 `object` 또는 `data object`를 사용한다.
+- enum은 값 목록과 닫힌 선택지를 표현할 때 사용하고, 더 복잡한 상태 전이는 sealed hierarchy가 더 나은지 검토한다.
+
+## 객체 생성과 API 설계
+
+- secondary constructor보다 factory function이나 primary constructor + named optional args가 더 단순한지 먼저 검토한다.
+- 복잡한 객체 생성은 DSL이나 builder 스타일이 실제로 읽기 쉬울 때만 도입한다.
+- 의존성은 직접 생성보다 주입을 우선 검토한다.
+- Boolean flag 인자가 의미를 숨기면 named argument, 별도 함수, 명시적 타입으로 분리한다.
+- 기본값과 named argument로 읽기 쉬워질 수 있으면 overload보다 우선 검토한다.
+- 타입 추론이 계약을 흐리면 명시적 타입 선언을 추가한다.
+- 프로퍼티는 상태를 표현하고, 비용 큰 연산이나 부수효과는 함수로 드러낸다.
+- `Unit?` 반환이나 nullable side-effect API는 기본 선택지로 두지 않는다.
+
+## 함수와 추상화 설계
+
+- 각각의 함수는 가능한 한 하나의 추상화 수준으로 유지한다.
+- 반복되는 알고리즘과 knowledge는 중복하지 않는다.
+- 재사용 가치가 높은 알고리즘은 제네릭으로 일반화할 수 있는지 검토한다.
+- 타입 매개변수 이름은 표준 관례를 따르되, 바깥 타입 매개변수와 shadowing되지 않게 유지한다.
+- variance(`out`, `in`)는 producer/consumer 의미가 분명할 때만 선언한다.
+- top-level function은 특정 타입의 부수속물이 아니라 모듈 공용 동작일 때만 사용한다.
+- extension function은 자연스러운 vocabulary 확장일 때만 사용하고, import 없이는 발견하기 어려운 핵심 로직을 숨기지 않는다.
+- member extension은 발견성과 dispatch 이해를 어렵게 하면 피한다.
+- interface, adapter, facade 같은 추상화는 외부 변경으로부터 코드를 실제로 보호할 때만 도입한다.
+- 가시성은 가능한 최소로 유지한다.
+- 중요한 계약, failure mode, thread-safety, nullability는 문서와 타입으로 정의한다.
+
+## 컬렉션과 데이터 처리
+
+- 작은 컬렉션 처리나 한 번의 순회가 더 읽기 쉬우면 collection 연산보다 명시 loop를 선택한다.
+- `List`/`Set`/`Map`의 read-only view와 truly immutable collection을 혼동하지 않도록 프로젝트 기준을 분명히 한다.
+- `Sequence`는 처리 단계가 둘 이상이고 laziness 이득이 실제로 있을 때만 사용한다.
+- `asSequence()`를 습관적으로 붙이지 않고, 실제 비용 감소와 가독성 이점을 비교한다.
+- `Flow`는 비동기 스트림, backpressure, cancellation 모델이 필요한 경우에만 사용하고 단순 일회성 값 전달에 남용하지 않는다.
+- 요소들을 key 기반으로 반복 조회하면 `Map`으로 재구성할 수 있는지 검토한다.
+- 단순 `groupBy`보다 `groupingBy`가 메모리/연산 측면에서 더 적합한지 검토한다.
+- `map/filter/groupBy/associate` 체인이 커질수록 연산 횟수를 줄일 수 있는지 다시 확인한다.
+- 성능이 중요한 경로는 원시형 배열이나 primitive specialization을 검토한다.
+- mutation이 실제로 더 단순하고 빠르면 mutable collection을 제한적으로 사용한다.
+- 목적에 맞는 컬렉션 타입(`List`, `Set`, `Map`, `ArrayDeque`, `LinkedHashMap` 등)을 명시적으로 선택한다.
+
+## 예외와 결과 표현
+
+- precondition 위반은 `require`, 상태 위반은 `check`, 도달 불가 분기는 `error`처럼 의도가 드러나는 표준 함수를 우선 사용한다.
+- 모든 실패를 `Result`로 감싸기보다 nullable, sealed result, exception 중 호출자가 가장 명확히 이해할 수 있는 계약을 선택한다.
+- broad `runCatching`으로 큰 블록 전체를 감싸 핵심 제어 흐름을 숨기지 않는다.
+- `CancellationException`을 일반 실패처럼 삼키지 않고 coroutine cancellation 의미를 보존한다.
+- 사용자 정의 오류보다 표준 오류 타입과 표준 precondition 도구를 우선 검토한다.
+- 테스트 가능성과 계약 재현성은 언어 기능 선택의 일부로 본다.
+
+## 동시성과 비동기
+
+- shared mutable state보다 immutability, confinement, message passing으로 임계 영역 자체를 줄일 수 있는지 먼저 검토한다.
+- coroutine은 structured concurrency 안에서 사용하고 `GlobalScope`는 기본 선택지로 쓰지 않는다.
+- `suspend` 함수는 실제 비동기/취소 가능 경계를 표현할 때만 사용한다.
+- dispatcher 선택은 호출자 책임인지 내부 구현 책임인지 프로젝트 기준을 정한다.
+- blocking I/O와 CPU-bound 작업은 서로 다른 dispatcher 전략이 필요한지 분리해 검토한다.
+- `launch`와 `async`는 fire-and-forget인지 결과 수집인지 의도를 분명히 나눠 사용한다.
+- `Flow`는 cold/hot/shared/state 구분이 실제 모델에 도움이 될 때만 사용한다.
+- `buffer`, `conflate`, `debounce`, `flowOn`, `catch`, `retry` 같은 연산자는 의미와 취소 모델이 더 명확해질 때만 사용한다.
+- correctness를 sleep, timing, scheduler 우연성에 기대지 않는다.
+
+## Interop, Reflection, Serialization
+
+- Java API는 platform type을 그대로 전파하지 말고 Kotlin 경계에서 계약을 명시화한다.
+- Kotlin public API를 Java에서도 쓸 계획이면 named/default parameter 의존, top-level 선언, companion API 노출 방식을 함께 검토한다.
+- primitive/nullability/checked exception 차이 때문에 Java와 Kotlin 양쪽 호출자가 다르게 오해하지 않게 계약을 문서화한다.
+- annotation은 명명 패턴보다 선언적 메타데이터가 실제로 더 안전할 때 사용한다.
+- reflection은 꼭 필요할 때만 도입하고, 명시적 계약이나 code generation으로 대체 가능한지 먼저 검토한다.
+- serialization 방식은 `kotlinx.serialization`, Jackson 등 프로젝트 표준을 정하고 혼용을 최소화한다.
+- compiler plugin, annotation processor, reflection 기반 magic은 핵심 흐름을 숨기지 않는 범위에서만 허용한다.
+- Lombok, Jackson, JPA proxy 같은 Java 생태계 도구와의 interop 제약은 `[프로젝트 결정 필요]`로 남긴다.
+
+## Import 와 Dependency 사용 관례
+
+- tool이 강제하는 import 순서와 format 규칙을 우선 따른다.
+- typealias는 긴 타입을 줄이기보다 도메인 의미가 더 선명해질 때만 사용한다.
+- operator overload, infix function, 구조 분해, 위임 프로퍼티는 문법적 편의보다 의미가 더 선명해질 때만 사용한다.
+- delegated property는 lazy initialization, observable state, backing store 추상화처럼 명확한 목적이 있을 때만 사용한다.
+- `lazy` 초기화는 비용, thread-safety 모드, 수명주기와 맞는지 확인한다.
+- DSL은 프로젝트 전체 readability를 실제로 높일 때만 도입하고 숨은 부수효과를 만들지 않는다.
+
+## 패키지와 파일 구조
+
+- 패키지 구조는 프로젝트의 구조 문서가 정한 책임 경계를 먼저 드러내고, framework 중심 그룹화만 남지 않게 정한다.
+- public 타입 이름은 역할 중심 명사로 두고, 구현 상세가 드러나는 `Impl`, `Util`, `Helper` 남용은 피한다.
+- 하나의 파일에는 함께 변경될 이유가 높은 선언만 둔다. 붙어 다니지 않는 extension, top-level constant, helper를 관성적으로 한 파일에 몰아넣지 않는다.
+- `data class`, `sealed hierarchy`, `value class`는 파일 배치만으로도 관계가 읽히게 유지한다.
 
 ## 테스트 관례 초안
 
 - 테스트 이름은 동작과 기대 결과를 읽기 쉬운 문장으로 작성한다.
 - coroutine 테스트는 실제 비동기 경계를 드러내는 경우에만 사용하고 임의 sleep 기반 검증은 피한다.
-- mock은 외부 협력 경계에서만 제한적으로 사용하고, data class 비교와 상태 검증으로 충분한 경우 우선 단순하게 유지한다.
+- `runTest`, test dispatcher, virtual time, Turbine 사용 여부를 프로젝트 기준으로 정한다.
+- `data class`, `sealed hierarchy`, `value class` 선택은 값 비교, exhaustiveness, serialization/interop 관점에서 테스트로 확인한다.
+- mock은 외부 협력 경계에서만 제한적으로 사용하고, 상태 검증과 값 비교로 충분한 경우 우선 단순하게 유지한다.
+- framework 통합 테스트는 실제 연결 책임이 있는 위치에만 사용하고, 단위 테스트로 충분한 책임까지 과도하게 끌어오지 않는다.
+
+## 자주 생기는 품질 리스크와 금지 패턴
+
+- `!!` 남용
+- 여러 scope function을 겹쳐 receiver와 부수효과가 흐려지는 코드
+- `data class`를 mutable entity처럼 사용하는 설계
+- 모든 반환값을 nullable 또는 `Result`로 통일해 오히려 의미가 흐려지는 계약
+- 작은 데이터 처리에도 습관적으로 `Sequence`, `Flow`를 붙여 디버깅 난도를 높이는 코드
+- coroutine 안에서 blocking 호출을 숨기는 코드
+- platform type을 그대로 내부 레이어로 퍼뜨리는 interop 코드
+- reflection, annotation magic, compiler plugin 의존으로 핵심 흐름을 숨기는 구조
 
 ## 확인 필요 항목
 
-- formatter와 lint 도구(`ktlint`, `detekt`, `spotless` 등)
-- coroutine 테스트 도구와 dispatcher 정책
+- 기준 Kotlin 버전과 target runtime(JVM/Android/MPP)
+- formatter와 lint 도구(`ktlint`, `detekt`, `spotless` 등) 및 import/format 규칙 자동 강제 범위
+- coroutine 테스트 도구(`kotlinx-coroutines-test`, `Turbine` 등)와 dispatcher 정책
 - Java interop, nullability annotation, transaction 사용 원칙
+- serialization 방식(`kotlinx.serialization`, Jackson 등) `[프로젝트 결정 필요]`
+- explicit API mode, context receivers, compiler plugin, reflection 사용 여부 `[프로젝트 결정 필요]`

--- a/harness.log
+++ b/harness.log
@@ -170,3 +170,15 @@ harness-kit core의 의미 있는 변경 이력을 남긴다.
   이유: Java 프로젝트가 bootstrap 자산만으로도 최신 JDK 기능 활용, `Effective Java` 계열 설계 원칙, code style과 convention의 책임 분리를 함께 가져갈 수 있어야 하며, 실제 코드리뷰에서 반복되는 Java-specific 선택을 장별로 빠르게 찾아 현지화할 수 있어야 하기 때문이다.
   audit: changed-parts + whole-harness
   audit-summary: changed-parts와 whole-harness는 최초 점검에서 JDK 기준점이 `17+`, `21+`, `24+`로 폐쇄적으로 읽히고 virtual thread 및 Java 24+ 지침이 project-specific runtime 전략처럼 보일 수 있어 승인 불가였다. 이후 기준점을 대표 예시와 이후 GA 버전까지 열어 두고, virtual thread와 stream gatherer를 기본 강제가 아닌 비교 검토 및 `[프로젝트 결정 필요]` 대상으로 낮췄다. 추가 점검에서는 style-vs-convention 분리가 좋아졌지만 `Gradle` 직접 언급, core 품질 규칙 중복, 패키지 구조 문구의 architecture 기본값화, framework-specific 테스트 예시 때문에 승인 불가였고, 이를 build-tool neutral 표현, core 참조 축약, 구조 문서 일반화, framework-neutral 테스트 문구로 보정한 뒤 재감사에서 승인 가능으로 전환됐으며 최종 리스크는 low로 판단했다.
+
+- 관련 파일: `bootstrap/language_conventions/kotlin_coding_conventions_template.md`, `harness.log`
+  변경: Kotlin bootstrap convention 템플릿을 `Effective Kotlin`의 좋은 코드/코드 설계/효율성 분류와 `Kotlin in Action`의 언어 기능, interop, coroutine/flow 주제를 함께 참조해 다시 구성했다. 그 결과 안전성, 가독성, 재사용성, 추상화 설계, 객체 생성, 클래스 설계, 효율적인 컬렉션 처리, coroutine/flow, interop, DSL/위임, 테스트 관례까지 Kotlin-specific 판단 기준을 폭넓게 담도록 확장했다. 또한 code style과 convention을 분리해 import/format 같은 기계적 규칙은 formatter/linter/build 또는 CI check로 넘기고, 공통 품질 규칙은 core 가이드 참조로 유지했다.
+  이유: Kotlin 프로젝트가 bootstrap 자산만으로도 null-safety, 불변성, structured concurrency, extension/DSL, Java interop 같은 Kotlin 고유 판단 기준을 재현 가능하게 시작할 수 있어야 하며, `Effective Kotlin`의 설계 원칙과 `Kotlin in Action`의 언어/도구 사용 맥락을 함께 반영해 자동 검사 규칙과 사람이 판단해야 하는 convention 규칙의 경계를 분리해야 하기 때문이다.
+  audit: changed-parts + whole-harness
+  audit-summary: changed-parts와 whole-harness는 최초 점검에서 최신 항목의 `audit-summary`가 `pending` 상태로 남아 있어 승인 불가였다. 이후 완료형 판정 문장으로 기록을 보강한 뒤 재감사에서 승인 가능으로 전환됐으며, Kotlin 템플릿 본문은 bootstrap scope, core 참조 구조, Java sibling과의 구조 정렬성을 유지한 상태로 low risk로 판단했다.
+
+- 관련 파일: `bootstrap/language_conventions/java_coding_conventions_template.md`, `bootstrap/language_conventions/kotlin_coding_conventions_template.md`, `harness.log`
+  변경: Java와 Kotlin bootstrap convention 템플릿의 상단 구조와 주요 섹션 배치를 정렬했다. 두 문서 모두 `코드 스타일과 convention 분리`, `공통 품질 규칙 참조`, `적용 전 결정`, 언어별 참조 관점, `타입과 모델링`, `객체 생성과 API 설계`, `함수와 추상화 설계`, `컬렉션과 데이터 처리`, `예외와 결과 표현`, `동시성과 비동기`, `Interop/Reflection/Serialization`, `Import 와 Dependency 사용 관례`, `패키지와 파일 구조`, `테스트 관례 초안`, `자주 생기는 품질 리스크와 금지 패턴`, `확인 필요 항목` 순서로 맞췄다.
+  이유: 언어별 세부 규칙은 달라도 bootstrap 템플릿 세트의 골격과 탐색 순서는 비슷해야 사용자가 Java와 Kotlin 템플릿을 오가며 필요한 규칙을 더 빠르게 찾고, 언어 간 drift 없이 project convention 문서를 현지화할 수 있기 때문이다.
+  audit: changed-parts + whole-harness
+  audit-summary: changed-parts와 whole-harness는 최초 점검에서 최신 항목의 `audit-summary`가 `pending` 상태로 남아 있고, Java 템플릿 일부 규칙이 섹션 제목과 어긋난 위치에 배치돼 있어 승인 불가였다. 이후 기록을 완료형으로 보강하고 Java 템플릿에서 공통 메서드, 자원 수명주기, 제네릭 타입 안전성, 식별자 모델링 규칙을 더 맞는 섹션으로 재배치한 뒤 재감사에서 승인 가능으로 전환됐으며, Java와 Kotlin 템플릿은 언어별 차이를 유지한 채 공통 골격을 공유하는 low risk 상태로 판단했다.


### PR DESCRIPTION
## Summary
- expand the Kotlin bootstrap convention template with Effective-Kotlin and Kotlin-in-Action-inspired decision areas that teams can selectively copy into project conventions
- separate automatable style checks from judgment-heavy convention rules, and align the Java/Kotlin template skeleton for easier cross-language navigation
- record the Kotlin expansion and the Java/Kotlin template alignment audit trail in `harness.log`

Closes #19