### PR TITLE
simplify onboarding entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@
 
 - 현재 지원 범위: [`docs/version_support.md`](docs/version_support.md)
 - canonical 시작 문서: [`docs/quickstart.md`](docs/quickstart.md)
-- greenfield 상세판: [`docs/project_overlay/first_success_guide.md`](docs/project_overlay/first_success_guide.md)
-- 로컬 진단/validator 해석: [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)
+- greenfield 상세 reference: [`docs/project_overlay/first_success_guide.md`](docs/project_overlay/first_success_guide.md)
+- diagnostics reference: [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)
 
 ### 기존 프로젝트에 도입
 
 - 아직 `docs/project_entrypoint.md`나 vendored harness 기준 문서가 없거나, legacy `docs/harness_guide.md` 상태라면 이 경로부터 시작한다.
 - read-only 현재 상태 파악: [`docs/project_overlay/adopt_dry_run.md`](docs/project_overlay/adopt_dry_run.md)
-- local diagnostics 보조: [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)
+- diagnostics reference: [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)
 
 ### 이미 도입된 프로젝트 업그레이드
 
@@ -87,7 +87,7 @@
 - `docs/templates/task/`
   - 새 task를 시작할 때 복사해서 쓸 기본 산출물 템플릿을 둔다.
 - `docs/examples/`
-  - 기대 산출물 밀도를 보여 주는 예시 task들을 둔다.
+  - 기본 시작 경로가 아니라 필요할 때 보는 advanced/reference 예시 task들을 둔다.
 - `bootstrap/`
   - 프로젝트 스캐폴딩 또는 수동 복사에 쓰는 bootstrap 자산을 둔다.
 - [`scripts/bootstrap_init.py`](scripts/bootstrap_init.py)
@@ -186,8 +186,8 @@ maintainer 문서는 `harness-kit` core 의미 변경이 있을 때만 적용한
 
 1. 먼저 [`docs/quickstart.md`](docs/quickstart.md)부터 읽는다.
 2. `harness-kit`를 새 프로젝트로 가져온다.
-3. 새 프로젝트라면 [`docs/project_overlay/first_success_guide.md`](docs/project_overlay/first_success_guide.md)를, 기존 프로젝트 첫 도입이라면 [`docs/project_overlay/adopt_dry_run.md`](docs/project_overlay/adopt_dry_run.md)를, 이미 도입된 프로젝트 업그레이드라면 [`docs/project_overlay/downstream_harness_upgrade_guide.md`](docs/project_overlay/downstream_harness_upgrade_guide.md)를 본다.
-4. 로컬 진단 순서와 dry-run 해석은 [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)를 함께 본다.
+3. 새 프로젝트면 `quickstart`의 greenfield 경로를, 기존 프로젝트 첫 도입이면 brownfield 경로를, 이미 도입된 프로젝트 업그레이드면 upgrade 경로를 먼저 따른다.
+4. 상세 설명이 더 필요할 때만 greenfield는 [`docs/project_overlay/first_success_guide.md`](docs/project_overlay/first_success_guide.md)를, 기존 프로젝트 진단은 [`docs/project_overlay/local_diagnostics_and_dry_run.md`](docs/project_overlay/local_diagnostics_and_dry_run.md)를 reference로 본다.
 5. init CLI 또는 `docs/project_overlay/` 수동 복사로 최소 문서 세트를 만든다.
 6. 생성된 `docs/project_entrypoint.md`, `docs/decisions/README.md`, `docs/standard/coding_conventions_project.md`를 읽고 현재 프로젝트에서 먼저 확정해야 할 구조/정책/예외 결정이 있는지 확인한다.
 7. `vendor/harness-kit/`가 아닌 경로에 kit를 둘 예정이면 bootstrap 시점부터 `--vendor-path <actual-path>`를 사용해 generated vendored reference를 바로 현지화한다. 그 옵션 없이 생성했다면 이후 `docs/project_entrypoint.md`와 `docs/standard/coding_conventions_project.md`의 경로를 실제 배치 경로에 맞게 수동 현지화한다.

--- a/docs/project_overlay/README.md
+++ b/docs/project_overlay/README.md
@@ -4,9 +4,9 @@
 
 ## 첫 도입 가이드
 
-- 새 프로젝트 또는 거의 빈 프로젝트에서 first success를 빠르게 재현하려면 `docs/project_overlay/first_success_guide.md`를 먼저 본다.
-- init CLI를 쓰든 수동 복사를 쓰든, 이 가이드의 최소 문서 세트와 성공 상태를 기준으로 맞춘다.
-- 로컬에서 어떤 명령을 먼저 돌리고 dry-run 출력을 어떻게 읽을지는 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
+- 기본 시작 문서는 `docs/quickstart.md`다.
+- 새 프로젝트 또는 거의 빈 프로젝트에서 greenfield 상세 설명이 더 필요할 때만 `docs/project_overlay/first_success_guide.md`를 본다.
+- 로컬에서 어떤 명령을 먼저 돌리고 dry-run 출력을 어떻게 읽을지 막힐 때만 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
 
 ## Overlay Validator
 
@@ -18,7 +18,7 @@
 - 새 harness bundle 변경을 얼마나 조심해서 반영해야 하는지 분류하는 기준은 `docs/project_overlay/harness_upgrade_impact_policy.md`를 본다.
 - 새 harness bundle 변경을 실제로 어떤 순서와 기준으로 검토하고 반영할지는 `docs/project_overlay/downstream_harness_upgrade_guide.md`를 본다.
 - 새 harness bundle과 현재 overlay 사이의 사람 중심 diff review 항목은 `docs/project_overlay/downstream_overlay_diff_review_checklist.md`를 본다.
-- 사람이 읽는 overlay 완료 기준은 `docs/project_overlay/overlay_completion_checklist.md`를 보고, sample validation 예시는 `docs/examples/bootstrap-first-success/overlay_completion_validation_report.md`를 본다.
+- 사람이 읽는 overlay 완료 기준은 `docs/project_overlay/overlay_completion_checklist.md`를 보고, sample validation 예시는 필요할 때만 `docs/examples/bootstrap-first-success/overlay_completion_validation_report.md`를 참고한다.
 
 ## 필수 문서
 
@@ -40,7 +40,7 @@
 ## 권장 읽기 순서
 
 - 이 문서는 source repo 안의 project overlay template guide다.
-- 이 저장소에서는 먼저 `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`, `docs/how_harness_kit_works.md`를 본다.
+- 이 저장소에서는 먼저 `docs/quickstart.md`를 보고, 필요할 때만 `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`, `docs/how_harness_kit_works.md`로 이어진다.
 - 아래 순서는 downstream 프로젝트를 bootstrap한 뒤 생성되는 문서 기준이다.
 - 아래 vendored 경로 예시는 `vendor/harness-kit/` 기준이며, 다른 경로를 쓰면 같은 실제 경로로 읽는다.
 

--- a/docs/project_overlay/first_success_guide.md
+++ b/docs/project_overlay/first_success_guide.md
@@ -5,7 +5,9 @@
 ## 문서 역할
 
 - 이 문서는 greenfield first-success 상세판이다.
-- canonical 시작 경로를 먼저 고르려면 `docs/quickstart.md`를 보고, 실패 원인과 출력 해석은 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
+- canonical 시작 경로는 항상 `docs/quickstart.md`를 먼저 본다.
+- 이 문서는 quickstart의 greenfield 경로를 더 자세히 풀어 쓴 reference다.
+- 실패 원인과 출력 해석은 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
 - downstream 구조와 Phase 흐름 전체는 `docs/downstream_harness_flow.md`를 본다.
 - 새 서브에이전트가 가장 먼저 여는 onboarding 문서는 아니고, `docs/quickstart.md`에서 greenfield 경로를 고른 뒤에 읽는 문서다.
 
@@ -255,9 +257,9 @@ docs/
 
 ## 참고 검증 자산
 
-- 실제 end-to-end smoke validation 예시는 `docs/examples/bootstrap-first-success/validation_report.md`를 본다.
+- 실제 end-to-end smoke validation 예시는 필요할 때만 `docs/examples/bootstrap-first-success/validation_report.md`를 본다.
 - init, validator, adopt dry-run의 로컬 진단 순서는 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
 - 사람이 읽는 overlay 완료 기준은 `docs/project_overlay/overlay_completion_checklist.md`를 본다.
-- overlay 완료 상태 sample validation 예시는 `docs/examples/bootstrap-first-success/overlay_completion_validation_report.md`를 본다.
+- overlay 완료 상태 sample validation 예시는 필요할 때만 `docs/examples/bootstrap-first-success/overlay_completion_validation_report.md`를 본다.
 - first success 이후 unresolved placeholder를 점검하려면 `docs/project_overlay/unresolved_decision_validator.md`를 본다.
 - 문서 간 교차 정합성을 점검하려면 `docs/project_overlay/cross_document_consistency_checker.md`를 본다.

--- a/docs/project_overlay/local_diagnostics_and_dry_run.md
+++ b/docs/project_overlay/local_diagnostics_and_dry_run.md
@@ -5,7 +5,8 @@
 ## 문서 역할
 
 - 이 문서는 진단과 출력 해석 전용 문서다.
-- canonical happy path 자체는 `docs/quickstart.md`와 `docs/project_overlay/first_success_guide.md`를 먼저 보고, 이 문서는 실패하거나 출력 의미가 헷갈릴 때 참고한다.
+- canonical happy path 자체는 `docs/quickstart.md`를 먼저 보고, greenfield 상세 설명이 더 필요할 때만 `docs/project_overlay/first_success_guide.md`를 본다.
+- 이 문서는 실패하거나 출력 의미가 헷갈릴 때 참고하는 diagnostics reference다.
 - downstream 구조와 Phase 흐름 전체는 `docs/downstream_harness_flow.md`를 본다.
 - 현재 지원 범위와 최신 릴리스는 `docs/version_support.md`를 기준으로 본다.
 
@@ -243,7 +244,8 @@ python3 vendor/harness-kit/scripts/validate_overlay_consistency.py .
 
 ## 관련 문서
 
-- 새 프로젝트 first success: `docs/project_overlay/first_success_guide.md`
+- canonical 시작 문서: `docs/quickstart.md`
+- 새 프로젝트 first-success 상세판: `docs/project_overlay/first_success_guide.md`
 - 기존 프로젝트 read-only 비교: `docs/project_overlay/adopt_dry_run.md`
 - 기존 프로젝트 제한적 write: `docs/project_overlay/adopt_safe_write.md`
 - unresolved placeholder readiness: `docs/project_overlay/unresolved_decision_validator.md`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,10 +5,10 @@
 ## 문서 역할
 
 - 이 문서는 canonical happy path를 고르는 빠른 시작 문서다.
-- greenfield 상세판은 `docs/project_overlay/first_success_guide.md`를, 실패 원인과 출력 해석은 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
+- greenfield 상세 설명이 더 필요할 때만 `docs/project_overlay/first_success_guide.md`를, 실패 원인과 출력 해석이 필요할 때만 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 본다.
 - downstream 구조와 Phase 흐름 전체 설명은 `docs/downstream_harness_flow.md`를 본다.
 - 현재 지원 범위와 최신 릴리스는 `docs/version_support.md`를 기준으로 본다.
-- 새 서브에이전트라면 이 문서를 첫 문서로 본다. 다른 onboarding 문서는 이 문서에서 경로를 고른 뒤에만 이어서 읽는다.
+- 새 서브에이전트와 새 사용자는 이 문서를 첫 문서로 본다. 다른 onboarding 문서는 이 문서에서 경로를 고른 뒤 필요할 때만 이어서 읽는다.
 
 ## 누구를 위한 문서인가
 
@@ -40,9 +40,7 @@
 1. `harness-kit`를 프로젝트 안의 vendored 경로로 둔다.
     - 아래 예시는 `vendor/harness-kit/`를 기준으로 한다.
     - 다른 경로를 쓰면 문서 안의 vendored path와 예시 명령의 `vendor/harness-kit/` 부분을 모두 같은 실제 경로로 바꿔서 실행한다.
-2. `docs/project_overlay/first_success_guide.md`를 본다.
-3. `docs/project_overlay/local_diagnostics_and_dry_run.md`를 같이 본다.
-4. 먼저 bootstrap만 실행한다.
+2. 먼저 bootstrap만 실행한다.
 
 - `bootstrap_init.py`, `check_first_success_docs.py`, validator 예시는 모두 Python 3 runtime이 필요하다.
 - 현재 bootstrap CLI는 `python`, `java`, `kotlin` language profile을 지원하지만, 실행 자체는 Python 3로 한다.
@@ -53,14 +51,14 @@
 python3 vendor/harness-kit/scripts/bootstrap_init.py . --language python
 ```
 
-5. bootstrap 직후 `docs/project_entrypoint.md`와 `docs/decisions/README.md`를 먼저 읽고, 현재 프로젝트에서 구조/정책/예외/책임 위치 중 바로 확정해야 할 결정이 있는지 확인한다.
+3. bootstrap 직후 `docs/project_entrypoint.md`와 `docs/decisions/README.md`를 먼저 읽고, 현재 프로젝트에서 구조/정책/예외/책임 위치 중 바로 확정해야 할 결정이 있는지 확인한다.
 
-6. `harness-kit`를 `vendor/harness-kit/` 이외의 경로에 두었다면, bootstrap 때 `--vendor-path`를 이미 준 경우 generated reference는 바로 맞는다. 그 옵션 없이 생성했다면 validator를 돌리기 전에 아래 파일의 vendored 경로를 실제 배치 경로로 먼저 현지화한다.
+4. `harness-kit`를 `vendor/harness-kit/` 이외의 경로에 두었다면, bootstrap 때 `--vendor-path`를 이미 준 경우 generated reference는 바로 맞는다. 그 옵션 없이 생성했다면 validator를 돌리기 전에 아래 파일의 vendored 경로를 실제 배치 경로로 먼저 현지화한다.
 
 - `docs/project_entrypoint.md`
 - `docs/standard/coding_conventions_project.md`
 
-7. 그다음 아래 검증 명령을 실행한다.
+5. 그다음 아래 검증 명령을 실행한다.
 
 ```bash
 python3 vendor/harness-kit/scripts/check_first_success_docs.py .
@@ -68,23 +66,27 @@ python3 vendor/harness-kit/scripts/validate_overlay_decisions.py . --readiness f
 python3 vendor/harness-kit/scripts/validate_overlay_consistency.py .
 ```
 
-8. local validator가 통과하면 `docs/project_overlay/harness_doc_guard_workflow_template.yml`을 프로젝트 `.github/workflows/` 아래 workflow 파일로 복사하고 workflow 안의 `@<pin-tag-or-sha>`를 실제 릴리스 태그 또는 고정 SHA로 바꾼다.
+6. local validator가 통과하면 `docs/project_overlay/harness_doc_guard_workflow_template.yml`을 프로젝트 `.github/workflows/` 아래 workflow 파일로 복사하고 workflow 안의 `@<pin-tag-or-sha>`를 실제 릴리스 태그 또는 고정 SHA로 바꾼다.
 
-9. 첫 task를 시작하기 전에 `docs/downstream_harness_flow.md`를 한 번 읽고 Phase 1~5, approval gate, 재수행 규칙을 먼저 이해한다.
-10. `vendor/harness-kit/docs/templates/task/`를 프로젝트 작업 경로로 복사해 첫 task를 시작한다.
-11. task를 시작하면 `phase_status.md`에 현재 gate와 허용 write-set을 먼저 적고, 필요할 때 아래 validator로 hard-stop 위반을 점검한다.
+7. 첫 task를 시작하기 전에 `docs/downstream_harness_flow.md`를 한 번 읽고 Phase 1~5, approval gate, 재수행 규칙을 먼저 이해한다.
+8. `vendor/harness-kit/docs/templates/task/`를 프로젝트 작업 경로로 복사해 첫 task를 시작한다.
+9. task를 시작하면 `phase_status.md`에 현재 gate와 허용 write-set을 먼저 적고, 필요할 때 아래 validator로 hard-stop 위반을 점검한다.
 
 ```bash
 python3 vendor/harness-kit/scripts/validate_phase_gate.py docs/task/<task_id> --paths docs/task/<task_id>/issue.md docs/task/<task_id>/phase_status.md
 ```
+
+상세 설명이 더 필요하면 아래 reference로 이어서 읽는다.
+
+- greenfield 상세판: `docs/project_overlay/first_success_guide.md`
+- 로컬 진단/출력 해석: `docs/project_overlay/local_diagnostics_and_dry_run.md`
 
 ### 기존 프로젝트 첫 도입
 
 - 아직 `docs/project_entrypoint.md`가 없거나, legacy `docs/harness_guide.md`만 남아 있거나, 최소 overlay 문서 세트가 아직 맞춰지지 않았다면 이 경로를 따른다.
 
 1. `docs/project_overlay/adopt_dry_run.md`를 본다.
-2. `docs/project_overlay/local_diagnostics_and_dry_run.md`를 같이 본다.
-3. 아래 명령을 실행한다.
+2. 아래 명령을 실행한다.
 
 - 아래 명령도 downstream 프로젝트 루트에서 실행한다.
 
@@ -92,41 +94,43 @@ python3 vendor/harness-kit/scripts/validate_phase_gate.py docs/task/<task_id> --
 python3 vendor/harness-kit/scripts/adopt_dry_run.py . --language python
 ```
 
-4. 결과를 아래처럼 읽는다.
+3. 결과를 아래처럼 읽는다.
     - `missing files`: 안전하게 생성 가능한 후보
     - `existing but unchanged targets`: baseline과 동일
     - `differing files`: 수동 검토 대상
     - `conflict candidates`: 수동 판단 우선 대상
     - `legacy entrypoint migration candidates`: 예전 `docs/harness_guide.md`를 새 canonical `docs/project_entrypoint.md`로 옮겨야 하는 상태
-5. `legacy entrypoint migration candidates`가 보이면 아래 rename migration부터 먼저 검토한다.
+4. `legacy entrypoint migration candidates`가 보이면 아래 rename migration부터 먼저 검토한다.
 
 ```bash
 python3 vendor/harness-kit/scripts/adopt_safe_write.py . --language python --migrate-legacy-entrypoint
 ```
 
-6. legacy migration candidate가 없고 `missing files`를 먼저 안전하게 반영하려면 아래 명령을 실행한다.
+5. legacy migration candidate가 없고 `missing files`를 먼저 안전하게 반영하려면 아래 명령을 실행한다.
 
 ```bash
 python3 vendor/harness-kit/scripts/adopt_safe_write.py . --language python
 ```
 
-7. exact-match target만 다시 쓰거나 특정 경로만 명시적으로 덮어쓰려면 아래처럼 범위를 좁힌다.
+6. exact-match target만 다시 쓰거나 특정 경로만 명시적으로 덮어쓰려면 아래처럼 범위를 좁힌다.
 
 ```bash
 python3 vendor/harness-kit/scripts/adopt_safe_write.py . --language python --update-unchanged
 python3 vendor/harness-kit/scripts/adopt_safe_write.py . --language python --force-overwrite docs/project_entrypoint.md
 ```
 
-8. `differing files`와 `conflict candidates`는 기본적으로 수동 비교 대상으로 남긴다.
-9. partial adoption 상태가 structurally safe한지 먼저 보려면 아래 incremental validator를 실행한다.
-10. 최소 문서 세트가 어느 정도 맞춰진 뒤에만 full validator로 넘어간다.
-11. 첫 task를 시작하기 전에 `docs/downstream_harness_flow.md`를 한 번 읽고 Phase 1~5, approval gate, 재수행 규칙을 먼저 이해한다.
+7. `differing files`와 `conflict candidates`는 기본적으로 수동 비교 대상으로 남긴다.
+8. partial adoption 상태가 structurally safe한지 먼저 보려면 아래 incremental validator를 실행한다.
+9. 최소 문서 세트가 어느 정도 맞춰진 뒤에만 full validator로 넘어간다.
+10. 첫 task를 시작하기 전에 `docs/downstream_harness_flow.md`를 한 번 읽고 Phase 1~5, approval gate, 재수행 규칙을 먼저 이해한다.
 
 ```bash
 python3 vendor/harness-kit/scripts/validate_overlay_consistency.py . --mode incremental
 python3 vendor/harness-kit/scripts/validate_overlay_decisions.py . --readiness first-success
 python3 vendor/harness-kit/scripts/validate_overlay_consistency.py .
 ```
+
+출력 해석과 로컬 진단 순서가 더 필요하면 `docs/project_overlay/local_diagnostics_and_dry_run.md`를 reference로 본다.
 
 ### 이미 도입된 downstream 업그레이드
 
@@ -180,8 +184,8 @@ python3 vendor/harness-kit/scripts/validate_overlay_consistency.py .
 ## 다음에 읽을 문서
 
 - 전체 동작 설명: `docs/how_harness_kit_works.md`
-- 새 프로젝트 시작: `docs/project_overlay/first_success_guide.md`
-- 로컬 진단: `docs/project_overlay/local_diagnostics_and_dry_run.md`
+- greenfield 상세 reference: `docs/project_overlay/first_success_guide.md`
+- diagnostics reference: `docs/project_overlay/local_diagnostics_and_dry_run.md`
 - 기존 프로젝트 dry-run: `docs/project_overlay/adopt_dry_run.md`
 - 기존 프로젝트 bundle upgrade 절차: `docs/project_overlay/downstream_harness_upgrade_guide.md`
 - 기존 프로젝트 diff review checklist: `docs/project_overlay/downstream_overlay_diff_review_checklist.md`

--- a/docs/task/122_simplify_onboarding_and_doc_guard/implementation_notes.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/implementation_notes.md
@@ -1,0 +1,28 @@
+# Implementation Notes
+
+## 진행 로그
+
+- quickstart를 canonical 시작 문서로 더 분명히 세우고, first-success/local diagnostics는 상세 reference로 내리는 방향으로 범위를 확정했다.
+- 구현: `README.md`, `docs/quickstart.md`, `docs/project_overlay/README.md`, `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`에서 온보딩 중복을 줄이고 role wording을 정리했다.
+- 구현: `scripts/check_harness_docs.py`에서 example sample validation과 phrase-level 결합 검사를 줄이고 구조/경로 중심 검사를 남겼다.
+
+## 경량 검토 기록
+
+- 해당 없음
+
+## 구현 중 결정 사항
+
+- repo-local 근거: `README.md`, `docs/quickstart.md`, `docs/project_overlay/README.md`, `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`, `scripts/check_harness_docs.py`
+- repo에 없어 문서화/승인 대상으로 넘긴 결정: 없음
+
+## 위임된 책임
+
+- 없음
+
+## 사용자 승인 필요 항목
+
+- 없음
+
+## 후속 태스크 후보
+
+- README와 `docs/how_harness_kit_works.md`의 시작 경로 설명도 더 강하게 quickstart 중심으로 압축할 수 있다.

--- a/docs/task/122_simplify_onboarding_and_doc_guard/issue.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/issue.md
@@ -1,0 +1,24 @@
+# Issue
+
+## 배경
+
+- 현재 harness-kit는 runtime contract 자체보다 onboarding 문서층, example 노출, maintainer용 doc guard 결합도가 무겁게 느껴진다.
+- 특히 quickstart 외에도 first success, local diagnostics, README가 같은 시작 흐름을 반복하고, doc guard가 예시 문서와 표현 문구까지 강하게 결합해 유지 비용을 높인다.
+
+## 요청사항
+
+- `docs/quickstart.md`를 canonical 시작 문서로 더 분명히 고정한다.
+- `README.md`, `docs/project_overlay/README.md`, `first_success_guide.md`, `local_diagnostics_and_dry_run.md`의 온보딩 중복을 완화한다.
+- `scripts/check_harness_docs.py`에서 example/phrase-level 결합을 줄이고 구조 중심 검증으로 완화한다.
+- examples는 기본 소비 경로보다 reference/advanced 위치로 조정한다.
+
+## 비범위
+
+- phase runtime contract 또는 self-healing/stale invalidation 규칙 삭제
+- 핵심 validator 제거
+- downstream bundle 경계 재설계
+
+## 승인 또는 제약 조건
+
+- quickstart를 기본 진입점으로 두되, 상세 reference 문서는 유지한다.
+- 경량화는 구조 유지와 운영 부담 완화에 집중하고, 기존 핵심 runtime contract는 약화하지 않는다.

--- a/docs/task/122_simplify_onboarding_and_doc_guard/phase_status.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/phase_status.md
@@ -1,0 +1,36 @@
+# Phase Status
+
+## Current State
+
+- Task Status: `approval_required`
+- Current Phase: `Phase 5`
+- Current Gate: `documentation and validation complete`
+- Last Approved Phase: `없음`
+
+## Allowed Write Set
+
+- `$TASK/implementation_notes.md`
+- `$TASK/validation_report.md`
+- `$TASK/phase_status.md`
+
+## Locked Paths
+
+- `README.md`
+- `docs/quickstart.md`
+- `docs/project_overlay/README.md`
+- `docs/project_overlay/first_success_guide.md`
+- `docs/project_overlay/local_diagnostics_and_dry_run.md`
+- `scripts/check_harness_docs.py`
+
+## Stale Artifacts
+
+- 없음
+
+## Next Action
+
+- 사용자 확인 전에는 task-local 상태 기록만 갱신하고, 후속 수정이 생기면 가장 이른 영향 Phase와 write-set부터 다시 판정한다.
+
+## Cleanup
+
+- Task 종료 전 유지: `yes`
+- Task 종료 후 정리: `Phase 5` close-out 완료 뒤 최종 상태를 다른 산출물에 남기고 삭제할 수 있다.

--- a/docs/task/122_simplify_onboarding_and_doc_guard/plan.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/plan.md
@@ -1,0 +1,37 @@
+# Plan
+
+## 변경 대상 파일 또는 모듈
+
+- `README.md`
+- `docs/quickstart.md`
+- `docs/project_overlay/README.md`
+- `docs/project_overlay/first_success_guide.md`
+- `docs/project_overlay/local_diagnostics_and_dry_run.md`
+- `scripts/check_harness_docs.py`
+
+## 레이어별 작업 계획
+
+- quickstart를 canonical 시작 문서로 더 분명히 고정한다.
+- overlay/README와 세부 가이드에서 quickstart 우선, detailed reference 후순위 구조를 분명히 한다.
+- doc guard에서 example sample validation과 phrase-level 강결합 검사를 줄인다.
+- examples는 advanced/reference 위치라는 설명을 보강한다.
+
+## 테스트 계획
+
+- `python3 scripts/check_harness_docs.py`
+
+## 문서 반영 계획
+
+- onboarding 역할 분리를 `README.md`, `quickstart.md`, overlay 문서에 반영한다.
+- 관련 `docs/decisions/README.md` 또는 `DEC-###-slug.md` 읽기/수정/생성 필요 여부: 해당 없음
+- 새 decision이 필요하면 index 갱신 계획: 해당 없음
+
+## 비범위
+
+- validator semantics 변경
+- bundle boundary 재분류
+
+## 리스크 또는 확인 포인트
+
+- doc guard를 과도하게 완화하면 실제 구조 drift까지 놓칠 수 있으므로 구조/경로 중심 검사는 유지한다.
+- quickstart를 canonical로 세우되 세부 문서의 유용한 참고 정보는 잃지 않게 해야 한다.

--- a/docs/task/122_simplify_onboarding_and_doc_guard/requirements.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/requirements.md
@@ -1,0 +1,45 @@
+# Requirements
+
+## 기능 요구사항
+
+- `docs/quickstart.md`는 downstream 사용자가 가장 먼저 보는 canonical 시작 문서로 읽혀야 한다.
+- `README.md`와 `docs/project_overlay/README.md`는 quickstart를 먼저 가리키고, 세부 온보딩 문서는 reference 역할이 더 분명해야 한다.
+- `docs/project_overlay/first_success_guide.md`와 `docs/project_overlay/local_diagnostics_and_dry_run.md`는 quickstart의 상세 reference로 읽히도록 표현을 정리해야 한다.
+- `scripts/check_harness_docs.py`는 example 문서의 세부 표현과 sample validation 내용을 강하게 결합하지 않고, 구조/경로/핵심 섹션 위주로 검사해야 한다.
+- examples는 유지하되 기본 소비 경로보다 advanced/reference 위치로 설명해야 한다.
+
+## 비기능 요구사항 또는 품질 요구사항
+
+- 경량화는 기존 핵심 validator와 runtime contract를 약화하지 않는 최소 변경이어야 한다.
+- quickstart와 세부 문서 사이 역할 분리가 한눈에 읽혀야 한다.
+- doc guard는 불필요한 표현 drift에는 덜 민감하고, 구조 drift에는 여전히 민감해야 한다.
+
+## 입력/출력
+
+- 입력:
+  - `README.md`
+  - `docs/quickstart.md`
+  - `docs/project_overlay/README.md`
+  - `docs/project_overlay/first_success_guide.md`
+  - `docs/project_overlay/local_diagnostics_and_dry_run.md`
+  - `scripts/check_harness_docs.py`
+- 출력:
+  - 경량화된 onboarding 문서 설명층
+  - example/phrase-level 결합이 완화된 doc guard
+
+## 제약사항
+
+- existing quickstart/adoption/upgrade 경로는 유지한다.
+- example 문서를 삭제하지 않고 기본 진입점에서의 노출만 줄인다.
+
+## 예외 상황
+
+- 세부 reference 문서가 필요 없는 사용자는 quickstart만으로 시작할 수 있어야 한다.
+- maintainer smoke validation 문서와 examples는 남기되 guard의 강결합 대상으로 취급하지 않는다.
+
+## 성공 기준
+
+- quickstart가 유일한 기본 시작 문서로 읽힌다.
+- 세부 문서는 reference 성격이 더 분명해진다.
+- doc guard가 example/문구 결합보다 구조 중심으로 동작한다.
+- 관련 검증이 통과한다.

--- a/docs/task/122_simplify_onboarding_and_doc_guard/validation_report.md
+++ b/docs/task/122_simplify_onboarding_and_doc_guard/validation_report.md
@@ -1,0 +1,37 @@
+# Validation Report
+
+## 실행한 검증
+
+- 검증 항목: onboarding 문서 역할 분리 정렬 확인
+  - 대조한 입력물: `README.md`, `docs/quickstart.md`, `docs/project_overlay/README.md`, `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`
+  - 실행 방법 또는 확인 방식: quickstart 우선, 세부 reference 후순위 구조가 각 문서 역할 설명과 시작 경로에서 일관되게 읽히는지 수동 교차 검토했다.
+  - 결과: quickstart가 기본 진입점으로 더 분명해졌고, first-success/local diagnostics는 detailed reference 역할이 더 분명해졌다.
+  - 판정: `정합`
+  - 잔여 리스크: 아직 README와 개념 문서 일부에는 세부 문서 링크가 많이 남아 있어 추가 압축 여지가 있다.
+- 검증 항목: doc guard 검증
+  - 대조한 입력물: `scripts/check_harness_docs.py`, 변경된 온보딩 문서
+  - 실행 방법 또는 확인 방식: `python3 scripts/check_harness_docs.py`
+  - 결과: 통과
+  - 판정: `정합`
+  - 잔여 리스크: phrase-level 결합은 줄었지만, 여전히 maintainer용 doc guard 자체는 큰 스크립트다.
+
+## 실행하지 못한 검증
+
+- 없음
+
+## 결과 요약
+
+- 이번 판단의 repo-local 근거: `README.md`, `docs/quickstart.md`, `docs/project_overlay/README.md`, `docs/project_overlay/first_success_guide.md`, `docs/project_overlay/local_diagnostics_and_dry_run.md`, `scripts/check_harness_docs.py`
+- repo에 없어 후속 문서화/승인 대상으로 남긴 결정: 없음
+
+## Phase 5에서 반영할 related decisions/
+
+- 해당 없음
+
+## 남은 리스크
+
+- examples와 onboarding 관련 문서 수 자체는 여전히 많아서, 이후 더 과감한 문서 통합이 필요하다고 판단될 수 있다.
+
+## 후속 조치 필요 사항
+
+- 필요하면 README와 `docs/how_harness_kit_works.md`의 링크 계층도 더 축약한다.

--- a/scripts/check_harness_docs.py
+++ b/scripts/check_harness_docs.py
@@ -175,7 +175,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
     quickstart = read_text("docs/quickstart.md")
     first_success = read_text("docs/project_overlay/first_success_guide.md")
     diagnostics = read_text("docs/project_overlay/local_diagnostics_and_dry_run.md")
-    first_success_example = read_text("docs/examples/bootstrap-first-success/validation_report.md")
     bundle_smoke_doc = read_text("docs/kit_maintenance/downstream_bundle_smoke_validation.md")
     bundle_boundary = read_text("docs/kit_maintenance/downstream_bundle_boundary.md")
     project_guide_template = read_text("docs/project_overlay/project_entrypoint_template.md")
@@ -228,51 +227,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
     if "예시 명령의 `vendor/harness-kit/` 부분을 모두 같은 실제 경로로" not in quickstart:
         errors.append("docs/quickstart.md에 non-default vendoring command path localize 설명이 충분하지 않습니다.")
 
-    overlay_completion_example = read_text("docs/examples/bootstrap-first-success/overlay_completion_validation_report.md")
-    for required_path in readme_min:
-        if required_path not in overlay_completion_example:
-            errors.append(
-                f"docs/examples/bootstrap-first-success/overlay_completion_validation_report.md에 필수 문서 `{required_path}`가 반영되지 않았습니다."
-            )
-    overlay_completion_targets = set(
-        extract_bullet_paths(
-            extract_h2_section(
-                overlay_completion_example,
-                "판정 대상",
-            )
-        )
-    )
-    expected_explicit_targets = {
-        "AGENTS.md",
-        "CLAUDE.md",
-        "GEMINI.md",
-        "docs/project_entrypoint.md",
-        "docs/decisions/README.md",
-        "validate_overlay_decisions.py",
-        "validate_overlay_consistency.py",
-    }
-    missing_targets = expected_explicit_targets - overlay_completion_targets
-    if missing_targets:
-        joined = ", ".join(sorted(missing_targets))
-        errors.append(
-            "docs/examples/bootstrap-first-success/overlay_completion_validation_report.md의 판정 대상 목록이 현재 계약과 다릅니다: "
-            f"{joined}"
-        )
-
-    first_success_surfaces = {
-        "docs/quickstart.md": quickstart,
-        "docs/project_overlay/first_success_guide.md": first_success,
-        "docs/project_overlay/local_diagnostics_and_dry_run.md": diagnostics,
-        "docs/examples/bootstrap-first-success/validation_report.md": first_success_example,
-        "docs/kit_maintenance/downstream_bundle_smoke_validation.md": bundle_smoke_doc,
-    }
-    for rel_path, text in first_success_surfaces.items():
-        if "scripts/check_first_success_docs.py" in text:
-            continue
-        for required_path in readme_min:
-            if required_path not in text:
-                errors.append(f"{rel_path}에 최소 문서 세트 경로 `{required_path}`가 반영되지 않았습니다.")
-
     prerequisite_surfaces = {
         "docs/quickstart.md": quickstart,
         "docs/project_overlay/first_success_guide.md": first_success,
@@ -287,8 +241,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
         "docs/quickstart.md": quickstart,
         "docs/project_overlay/first_success_guide.md": first_success,
         "docs/project_overlay/local_diagnostics_and_dry_run.md": diagnostics,
-        "docs/examples/bootstrap-first-success/validation_report.md": first_success_example,
-        "docs/kit_maintenance/downstream_bundle_smoke_validation.md": bundle_smoke_doc,
     }
     for rel_path, text in helper_command_surfaces.items():
         if "scripts/check_first_success_docs.py" not in text:
@@ -302,7 +254,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
         "docs/project_overlay/cross_document_consistency_checker.md": read_text(
             "docs/project_overlay/cross_document_consistency_checker.md"
         ),
-        "docs/kit_maintenance/downstream_bundle_smoke_validation.md": bundle_smoke_doc,
     }
     for rel_path, text in incremental_surfaces.items():
         if "--mode incremental" not in text:
@@ -312,8 +263,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
         "docs/quickstart.md": quickstart,
         "docs/project_overlay/first_success_guide.md": first_success,
         "docs/project_overlay/local_diagnostics_and_dry_run.md": diagnostics,
-        "docs/examples/bootstrap-first-success/validation_report.md": first_success_example,
-        "docs/kit_maintenance/downstream_bundle_smoke_validation.md": bundle_smoke_doc,
     }
     for rel_path, text in localized_vendoring_surfaces.items():
         if "--vendor-path" not in text:
@@ -324,8 +273,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
         "docs/quickstart.md": quickstart,
         "docs/project_overlay/first_success_guide.md": first_success,
         "docs/project_overlay/local_diagnostics_and_dry_run.md": diagnostics,
-        "docs/examples/bootstrap-first-success/validation_report.md": first_success_example,
-        "docs/kit_maintenance/downstream_bundle_smoke_validation.md": bundle_smoke_doc,
     }
     for rel_path, text in workflow_template_surfaces.items():
         for token in ("docs/project_overlay/harness_doc_guard_workflow_template.yml", "@<pin-tag-or-sha>"):
@@ -336,20 +283,6 @@ def check_project_doc_path_consistency(errors: list[str]) -> None:
         errors.append(
             "docs/kit_maintenance/downstream_bundle_boundary.md에 project-facing workflow template 경로가 반영되지 않았습니다."
         )
-
-    for token in tuple(f"`{language}`" for language in LANGUAGE_BOOTSTRAP_PATHS) + (
-        "legacy entrypoint migration",
-        "--migrate-legacy-entrypoint",
-        "third_party/harness-kit",
-        "docs/project_overlay/harness_doc_guard_workflow_template.yml",
-        "@<pin-tag-or-sha>",
-    ):
-        if token not in bundle_smoke_doc:
-            errors.append(
-                "docs/kit_maintenance/downstream_bundle_smoke_validation.md에 bundle smoke coverage 설명이 부족합니다: "
-                f"{token}"
-            )
-
 
 def check_entrypoint_role_labels(errors: list[str]) -> None:
     expected_titles = {
@@ -411,26 +344,10 @@ def check_entrypoint_role_labels(errors: list[str]) -> None:
     local_entrypoint_joined = "\n".join(local_entrypoint_lines)
     if "## 실행 계약" not in local_entrypoint_joined:
         errors.append("project_overlay/README의 로컬 entrypoint 예시에 실행 계약 섹션이 없습니다.")
-    for phrase in (
-        "공통 규칙",
-        "프로젝트 전용 규칙",
-        "순서대로 모두 읽고 적용",
-        "둘 중 하나만 읽고 멈추지 않는다",
-    ):
-        if phrase not in local_entrypoint_joined:
-            errors.append(f"project_overlay/README의 로컬 entrypoint 예시에 traversal contract 문구 `{phrase}`가 없습니다.")
 
     runtime_entrypoint_joined = "\n".join(runtime_entrypoint_lines)
     if "## 실행 계약" not in runtime_entrypoint_joined:
         errors.append("project_overlay/README의 runtime entrypoint 예시에 실행 계약 섹션이 없습니다.")
-    for phrase in (
-        "순서대로 모두 읽고 적용",
-        "공통 규칙",
-        "프로젝트 전용 규칙",
-        "중간 문서에서 멈추지 않는다",
-    ):
-        if phrase not in runtime_entrypoint_joined:
-            errors.append(f"project_overlay/README의 runtime entrypoint 예시에 traversal contract 문구 `{phrase}`가 없습니다.")
 
 
 def check_decisions_templates(errors: list[str]) -> None:


### PR DESCRIPTION
## Summary
- make `docs/quickstart.md` the clearer default onboarding path and push greenfield/diagnostics detail into reference-oriented wording
- reduce repeated onboarding framing across README and project overlay guides so downstream users can choose a path without bouncing through multiple equivalent entry docs
- relax `scripts/check_harness_docs.py` so core structure and path checks stay enforced while examples and reference wording can evolve with less maintainer drag

## Validation
- `python3 scripts/check_harness_docs.py`

Closes #122